### PR TITLE
Fixing the link to your blog from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[aspires.github.com](aspires.github.com)
+[aspires.github.com](http://aspires.github.io/)
 
 Go there if you're looking around
 


### PR DESCRIPTION
Markdown was compiling the link as "https://github.com/aspires/aspires.github.com/blob/master/aspires.github.com" which was more than likely unintended. The change also takes into account the recent .com to .io changes in GitHub page URLs.
